### PR TITLE
Make module compatible with more nginx versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,13 @@ export PATH := $(PWD)/t/build/sbin:$(PWD)/t/build/bin:$(PATH)
 export PERL5LIB := $(PWD)/t/build/lib/perl5
 export UNBOUND_PID := $(PWD)/t/build/etc/unbound/unbound.pid
 
-nginx=nginx-1.7.7
-nginx_url=http://nginx.org/download/$(nginx).tar.gz
+unbound_version=1.4.22
+lua_jit_version=2.0.3
+lua_nginx_module_version=0.9.13rc1
+lua_upstream_nginx_module_version=0.02
+nginx_version=1.7.7
+nginx_no_pool_version?=$(nginx_version)
+nginx_url=http://nginx.org/download/nginx-$(nginx_version).tar.gz
 
 clean:
 	rm -rf t/build t/servroot t/tmp
@@ -38,75 +43,78 @@ t/build/lib/perl5: t/tmp/cpanm
 	$< -L t/build --notest https://github.com/openresty/test-nginx/archive/8d5c8668364251cdae01ccf1ef933d80b642982d.tar.gz
 	touch $@
 
-t/tmp/unbound-1.4.22.tar.gz: | t/tmp
-	curl -o $@ "http://unbound.net/downloads/unbound-1.4.22.tar.gz"
+t/tmp/unbound-$(unbound_version).tar.gz: | t/tmp
+	curl -o $@ "http://unbound.net/downloads/unbound-$(unbound_version).tar.gz"
 
-t/tmp/unbound-1.4.22: t/tmp/unbound-1.4.22.tar.gz
+t/tmp/unbound-$(unbound_version): t/tmp/unbound-$(unbound_version).tar.gz
 	tar -C t/tmp -xf $<
 	touch $@
 
-t/tmp/unbound-1.4.22/Makefile: | t/tmp/unbound-1.4.22
-	cd t/tmp/unbound-1.4.22 && ./configure --prefix=$(PWD)/t/build
+t/tmp/unbound-$(unbound_version)/Makefile: | t/tmp/unbound-$(unbound_version)
+	cd t/tmp/unbound-$(unbound_version) && ./configure --prefix=$(PWD)/t/build
 	touch $@
 
-t/tmp/unbound-1.4.22/unbound: t/tmp/unbound-1.4.22/Makefile
-	cd t/tmp/unbound-1.4.22 && make
+t/tmp/unbound-$(unbound_version)/unbound: t/tmp/unbound-$(unbound_version)/Makefile
+	cd t/tmp/unbound-$(unbound_version) && make
 	touch $@
 
-t/build/sbin/unbound: t/tmp/unbound-1.4.22/unbound
-	cd t/tmp/unbound-1.4.22 && make install
+t/build/sbin/unbound: t/tmp/unbound-$(unbound_version)/unbound
+	cd t/tmp/unbound-$(unbound_version) && make install
 	touch $@
 
-t/tmp/LuaJIT-2.0.3.tar.gz: | t/tmp
-	curl -o $@ "http://luajit.org/download/LuaJIT-2.0.3.tar.gz"
+t/tmp/LuaJIT-$(lua_jit_version).tar.gz: | t/tmp
+	curl -o $@ "http://luajit.org/download/LuaJIT-$(lua_jit_version).tar.gz"
 
-t/tmp/LuaJIT-2.0.3: t/tmp/LuaJIT-2.0.3.tar.gz
+t/tmp/LuaJIT-$(lua_jit_version): t/tmp/LuaJIT-$(lua_jit_version).tar.gz
 	tar -C t/tmp -xf $<
 	touch $@
 
-t/tmp/LuaJIT-2.0.3/src/luajit: | t/tmp/LuaJIT-2.0.3
-	cd t/tmp/LuaJIT-2.0.3 && make PREFIX=$(PWD)/t/build
+t/tmp/LuaJIT-$(lua_jit_version)/src/luajit: | t/tmp/LuaJIT-$(lua_jit_version)
+	cd t/tmp/LuaJIT-$(lua_jit_version) && make PREFIX=$(PWD)/t/build
 	touch $@
 
-t/build/bin/luajit: t/tmp/LuaJIT-2.0.3/src/luajit
-	cd t/tmp/LuaJIT-2.0.3 && make install PREFIX=$(PWD)/t/build
+t/build/bin/luajit: t/tmp/LuaJIT-$(lua_jit_version)/src/luajit
+	cd t/tmp/LuaJIT-$(lua_jit_version) && make install PREFIX=$(PWD)/t/build
 	touch $@
 
-t/tmp/lua-nginx-module-0.9.13rc1.tar.gz: | t/tmp
-	curl -Lo $@ "https://github.com/openresty/lua-nginx-module/archive/v0.9.13rc1.tar.gz"
+t/tmp/lua-nginx-module-$(lua_nginx_module_version).tar.gz: | t/tmp
+	curl -Lo $@ "https://github.com/openresty/lua-nginx-module/archive/v$(lua_nginx_module_version).tar.gz"
 
-t/tmp/lua-nginx-module-0.9.13rc1: t/tmp/lua-nginx-module-0.9.13rc1.tar.gz
+t/tmp/lua-nginx-module-$(lua_nginx_module_version): t/tmp/lua-nginx-module-$(lua_nginx_module_version).tar.gz
 	tar -C t/tmp -xf $<
 	touch $@
 
-t/tmp/lua-upstream-nginx-module-0.02.tar.gz: | t/tmp
-	curl -Lo $@ "https://github.com/openresty/lua-upstream-nginx-module/archive/v0.02.tar.gz"
+t/tmp/lua-upstream-nginx-module-$(lua_upstream_nginx_module_version).tar.gz: | t/tmp
+	curl -Lo $@ "https://github.com/openresty/lua-upstream-nginx-module/archive/v$(lua_upstream_nginx_module_version).tar.gz"
 
-t/tmp/lua-upstream-nginx-module-0.02: t/tmp/lua-upstream-nginx-module-0.02.tar.gz
+t/tmp/lua-upstream-nginx-module-$(lua_upstream_nginx_module_version): t/tmp/lua-upstream-nginx-module-$(lua_upstream_nginx_module_version).tar.gz
 	tar -C t/tmp -xf $<
 	touch $@
 
-t/tmp/$(nginx).tar.gz: | t/tmp
+t/tmp/nginx-$(nginx_version).tar.gz: | t/tmp
 	curl -o $@ $(nginx_url)
 
-t/tmp/$(nginx): t/tmp/$(nginx).tar.gz
+t/tmp/nginx-$(nginx_version): t/tmp/nginx-$(nginx_version).tar.gz
 	tar -C t/tmp -xf $<
 	touch $@
 
-t/tmp/$(nginx)/.patches-applied: | t/tmp/$(nginx)
-	curl https://raw.githubusercontent.com/openresty/no-pool-nginx/master/$(nginx)-no_pool.patch | patch -d t/tmp/$(nginx) -p1 --quiet
+t/tmp/nginx-$(nginx_no_pool_version)-no_pool.patch: | t/tmp
+	curl -o $@ https://raw.githubusercontent.com/openresty/no-pool-nginx/master/nginx-$(nginx_no_pool_version)-no_pool.patch
+
+t/tmp/nginx-$(nginx_version)/.patches-applied: | t/tmp/nginx-$(nginx_version) t/tmp/nginx-$(nginx_no_pool_version)-no_pool.patch
+	cat t/tmp/nginx-$(nginx_no_pool_version)-no_pool.patch | sed "s,.*nginx_version.*, `cat t/tmp/nginx-$(nginx_version)/src/core/nginx.h | grep nginx_version`," | sed 's,"$(nginx_no_pool_version),"$(nginx_version),' | patch -d t/tmp/nginx-$(nginx_version) -p1 --quiet
 	touch $@
 
-t/tmp/$(nginx)/Makefile: config | t/tmp/$(nginx) t/tmp/$(nginx)/.patches-applied t/build/bin/luajit t/tmp/lua-nginx-module-0.9.13rc1 t/tmp/lua-upstream-nginx-module-0.02
-	cd t/tmp/$(nginx) && env \
+t/tmp/nginx-$(nginx_version)/Makefile: config | t/tmp/nginx-$(nginx_version) t/tmp/nginx-$(nginx_version)/.patches-applied t/build/bin/luajit t/tmp/lua-nginx-module-$(lua_nginx_module_version) t/tmp/lua-upstream-nginx-module-$(lua_upstream_nginx_module_version)
+	cd t/tmp/nginx-$(nginx_version) && env \
 		LUAJIT_LIB=$(PWD)/t/build/lib \
 		LUAJIT_INC=$(PWD)/t/build/include/luajit-2.0 \
 		./configure \
 		--prefix=$(PWD)/t/build \
 		--with-debug \
 		--with-ipv6 \
-		--add-module=$(PWD)/t/tmp/lua-nginx-module-0.9.13rc1 \
-		--add-module=$(PWD)/t/tmp/lua-upstream-nginx-module-0.02 \
+		--add-module=$(PWD)/t/tmp/lua-nginx-module-$(lua_nginx_module_version) \
+		--add-module=$(PWD)/t/tmp/lua-upstream-nginx-module-$(lua_upstream_nginx_module_version) \
 		--add-module=$(PWD) \
 		--without-http_charset_module \
 		--without-http_userid_module \
@@ -125,8 +133,8 @@ t/tmp/$(nginx)/Makefile: config | t/tmp/$(nginx) t/tmp/$(nginx)/.patches-applied
 		--without-http_browser_module \
 		--without-http_upstream_ip_hash_module
 
-t/tmp/$(nginx)/objs/nginx: t/tmp/$(nginx)/Makefile *.c
-	cd t/tmp/$(nginx) && make
+t/tmp/nginx-$(nginx_version)/objs/nginx: t/tmp/nginx-$(nginx_version)/Makefile *.c
+	cd t/tmp/nginx-$(nginx_version) && make
 
-t/build/sbin/nginx: t/tmp/$(nginx)/objs/nginx
-	cd t/tmp/$(nginx) && make install
+t/build/sbin/nginx: t/tmp/nginx-$(nginx_version)/objs/nginx
+	cd t/tmp/nginx-$(nginx_version) && make install

--- a/t/dynamic_server.t
+++ b/t/dynamic_server.t
@@ -35,6 +35,7 @@ $ENV{TEST_NGINX_PRINT_UPSTREAMS_LOCATION} = <<_EOC_;
       local upstream = require "ngx.upstream"
       local get_servers = upstream.get_servers
       local get_upstreams = upstream.get_upstreams
+      local srv_keys={"addr","weight","fail_timeout","backup","down","max_fails"}
 
       local us = get_upstreams()
       for _, u in ipairs(us) do
@@ -45,18 +46,21 @@ $ENV{TEST_NGINX_PRINT_UPSTREAMS_LOCATION} = <<_EOC_;
         else
           for _, srv in ipairs(srvs) do
             local first = true
-            for k, v in pairs(srv) do
-              if first then
-                first = false
-                ngx.print("  ")
-              else
-                ngx.print(", ")
-              end
-              if type(v) == "table" then
-                table.sort(v)
-                ngx.print(k, " = {", concat(v, ", "), "}")
-              else
-                ngx.print(k, " = ", v)
+            for _, k in ipairs(srv_keys) do
+              local v = srv[k]
+              if v then
+                if first then
+                  first = false
+                  ngx.print("  ")
+                else
+                  ngx.print(", ")
+                end
+                if type(v) == "table" then
+                  table.sort(v)
+                  ngx.print(k, " = {", concat(v, ", "), "}")
+                else
+                  ngx.print(k, " = ", v)
+                end
               end
             end
             ngx.print("\\\\n")


### PR DESCRIPTION
@GUI I have changed the Makefile and updated the code to be compatible with nginx 1.6.2 and 1.9.11 like asked for on issues #2 and #7 respectively.

To run the tests with different setup we can do something like that

```
# default test suite
make test

# change the nginx version and apply the nearest no_pool patch available
make test nginx_version=1.6.2 nginx_no_pool_version=1.5.9

# change only nginx version, use a no_pool patch with equals version
make test nginx_version=1.7.0

# change nginx, lua modules and other dependencies
make test nginx_version=1.8.0 lua_nginx_module_version=0.10.1rc1 lua_upstream_nginx_module_version=0.04 nginx_no_pool_version=1.9.2

make test nginx_version=1.9.11 lua_nginx_module_version=0.10.1rc1 lua_upstream_nginx_module_version=0.04
```