### PR TITLE
Use nginx plus syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ http {
   resolver 8.8.8.8;
 
   upstream example {
-    dynamic_server example.com;
+    server example.com resolve;
   }
 }
 ```
@@ -33,7 +33,7 @@ http {
 
 ### dynamic_server
 
-**Syntax:** *dynamic_server address [parameters]*;  
+**Syntax:** *server address [parameters]*;
 **Context** *upstream*
 
 Defines a server for an upstream. The differences between the default `server` and `dynamic_server` implementation:
@@ -43,11 +43,12 @@ Defines a server for an upstream. The differences between the default `server` a
 
 The following parameters can be used (see nginx's [server documentation](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server) for details):
 
-*weight=number*  
-*max_fails=number*  
-*fail_timeout=time*  
-*backup*  
-*down*  
+*weight=number*
+*max_fails=number*
+*fail_timeout=time*
+*backup*
+*down*
+*resolve*
 
 # Compatibility
 

--- a/config
+++ b/config
@@ -1,3 +1,3 @@
 ngx_addon_name=ngx_http_upstream_dynamic_servers_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_upstream_dynamic_servers_module"
+HTTP_MODULES=$(echo $HTTP_MODULES | sed "s/ngx_http_upstream_module/ngx_http_upstream_dynamic_servers_module ngx_http_upstream_module/")
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_upstream_dynamic_servers.c"

--- a/ngx_http_upstream_dynamic_servers.c
+++ b/ngx_http_upstream_dynamic_servers.c
@@ -557,7 +557,7 @@ end:
     ngx_resolve_name_done(ctx);
 
     if (ngx_exiting) {
-        ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: worker is about to exit, do not set the timer again");
+        ngx_log_debug(NGX_LOG_DEBUG_CORE, ngx_cycle->log, 0, "upstream-dynamic-servers: worker is about to exit, do not set the timer again");
         return;
     }
 

--- a/ngx_http_upstream_dynamic_servers.c
+++ b/ngx_http_upstream_dynamic_servers.c
@@ -8,18 +8,18 @@
         ((u_char *) (n) - offsetof(ngx_resolver_node_t, node))
 
 typedef struct {
-  ngx_pool_t *pool;
-  ngx_pool_t *previous_pool;
-  ngx_http_upstream_server_t *server;
-  ngx_http_upstream_srv_conf_t *upstream_conf;
-  ngx_resolver_t *resolver;
-  ngx_msec_t resolver_timeout;
-  ngx_http_upstream_resolved_t *resolved;
-  ngx_event_t timer;
+    ngx_pool_t                   *pool;
+    ngx_pool_t                   *previous_pool;
+    ngx_http_upstream_server_t   *server;
+    ngx_http_upstream_srv_conf_t *upstream_conf;
+    ngx_resolver_t               *resolver;
+    ngx_msec_t                    resolver_timeout;
+    ngx_http_upstream_resolved_t *resolved;
+    ngx_event_t                   timer;
 } ngx_http_upstream_dynamic_server_conf_t;
 
 typedef struct {
-    ngx_array_t                      dynamic_servers;
+    ngx_array_t                   dynamic_servers;
 } ngx_http_upstream_dynamic_server_main_conf_t;
 
 static ngx_str_t ngx_http_upstream_dynamic_server_null_route = ngx_string("127.255.255.255");
@@ -35,45 +35,45 @@ static void ngx_http_upstream_dynamic_server_resolve_handler(ngx_resolver_ctx_t 
 static ngx_resolver_node_t *ngx_resolver_lookup_name(ngx_resolver_t *r, ngx_str_t *name, uint32_t hash);
 
 static ngx_command_t ngx_http_upstream_dynamic_servers_commands[] = {
-  {
-    ngx_string("dynamic_server"),
-    NGX_HTTP_UPS_CONF | NGX_CONF_1MORE,
-    ngx_http_upstream_dynamic_server_directive,
-    0,
-    0,
-    NULL
-  },
+    {
+        ngx_string("dynamic_server"),
+        NGX_HTTP_UPS_CONF | NGX_CONF_1MORE,
+        ngx_http_upstream_dynamic_server_directive,
+        0,
+        0,
+        NULL
+    },
 
-  ngx_null_command
+    ngx_null_command
 };
 
 static ngx_http_module_t ngx_http_upstream_dynamic_servers_module_ctx = {
-  NULL,                                         /* preconfiguration */
-  NULL,                                         /* postconfiguration */
+    NULL,                                         /* preconfiguration */
+    NULL,                                         /* postconfiguration */
 
-  ngx_http_upstream_dynamic_server_main_conf,   /* create main configuration */
-  NULL,                                         /* init main configuration */
+    ngx_http_upstream_dynamic_server_main_conf,   /* create main configuration */
+    NULL,                                         /* init main configuration */
 
-  NULL,                                         /* create server configuration */
-  ngx_http_upstream_dynamic_servers_merge_conf, /* merge server configuration */
+    NULL,                                         /* create server configuration */
+    ngx_http_upstream_dynamic_servers_merge_conf, /* merge server configuration */
 
-  NULL,                                         /* create location configuration */
-  NULL                                          /* merge location configuration */
+    NULL,                                         /* create location configuration */
+    NULL                                          /* merge location configuration */
 };
 
 ngx_module_t ngx_http_upstream_dynamic_servers_module = {
-  NGX_MODULE_V1,
-  &ngx_http_upstream_dynamic_servers_module_ctx,  /* module context */
-  ngx_http_upstream_dynamic_servers_commands,     /* module directives */
-  NGX_HTTP_MODULE,                                /* module type */
-  NULL,                                           /* init master */
-  NULL,                                           /* init module */
-  ngx_http_upstream_dynamic_servers_init_process, /* init process */
-  NULL,                                           /* init thread */
-  NULL,                                           /* exit thread */
-  ngx_http_upstream_dynamic_servers_exit_process, /* exit process */
-  NULL,                                           /* exit master */
-  NGX_MODULE_V1_PADDING
+    NGX_MODULE_V1,
+    &ngx_http_upstream_dynamic_servers_module_ctx,  /* module context */
+    ngx_http_upstream_dynamic_servers_commands,     /* module directives */
+    NGX_HTTP_MODULE,                                /* module type */
+    NULL,                                           /* init master */
+    NULL,                                           /* init module */
+    ngx_http_upstream_dynamic_servers_init_process, /* init process */
+    NULL,                                           /* init thread */
+    NULL,                                           /* exit thread */
+    ngx_http_upstream_dynamic_servers_exit_process, /* exit process */
+    NULL,                                           /* exit master */
+    NGX_MODULE_V1_PADDING
 };
 
 // Implement the "dynamic_server" directive so it's compatible with the nginx
@@ -82,208 +82,209 @@ ngx_module_t ngx_http_upstream_dynamic_servers_module = {
 // src/http/ngx_http_upstream.c (nginx version 1.7.7), and should be kept in
 // sync with nginx's source code. Customizations noted in comments.
 static char * ngx_http_upstream_dynamic_server_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *dummy) {
-  // BEGIN CUSTOMIZATION: "dynamic_server" differs from "server" implementation
-  ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
-  ngx_http_upstream_dynamic_server_main_conf_t  *udsmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_upstream_dynamic_servers_module);
+    // BEGIN CUSTOMIZATION: "dynamic_server" differs from "server" implementation
+    ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
+    ngx_http_upstream_dynamic_server_main_conf_t  *udsmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_upstream_dynamic_servers_module);
 
-  ngx_http_upstream_srv_conf_t *uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
-  // END CUSTOMIZATION
+    ngx_http_upstream_srv_conf_t *uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
+    // END CUSTOMIZATION
 
-  time_t                       fail_timeout;
-  ngx_str_t                   *value, s;
-  ngx_url_t                    u;
-  ngx_int_t                    weight, max_fails;
-  ngx_uint_t                   i;
-  ngx_http_upstream_server_t  *us;
+    time_t                       fail_timeout;
+    ngx_str_t                   *value, s;
+    ngx_url_t                    u;
+    ngx_int_t                    weight, max_fails;
+    ngx_uint_t                   i;
+    ngx_http_upstream_server_t  *us;
 
 #if nginx_version <= 1007002
-  if (uscf->servers == NULL) {
-      uscf->servers = ngx_array_create(cf->pool, 4,
-                                       sizeof(ngx_http_upstream_server_t));
-      if (uscf->servers == NULL) {
-          return NGX_CONF_ERROR;
-      }
-  }
+    if (uscf->servers == NULL) {
+        uscf->servers = ngx_array_create(cf->pool, 4,
+                                         sizeof(ngx_http_upstream_server_t));
+        if (uscf->servers == NULL) {
+            return NGX_CONF_ERROR;
+        }
+    }
 #endif
 
-  us = ngx_array_push(uscf->servers);
-  if (us == NULL) {
-    return NGX_CONF_ERROR;
-  }
+    us = ngx_array_push(uscf->servers);
+    if (us == NULL) {
+        return NGX_CONF_ERROR;
+    }
 
-  ngx_memzero(us, sizeof(ngx_http_upstream_server_t));
+    ngx_memzero(us, sizeof(ngx_http_upstream_server_t));
 
-  value = cf->args->elts;
+    value = cf->args->elts;
 
-  weight = 1;
-  max_fails = 1;
-  fail_timeout = 10;
+    weight = 1;
+    max_fails = 1;
+    fail_timeout = 10;
 
-  for (i = 2; i < cf->args->nelts; i++) {
+    for (i = 2; i < cf->args->nelts; i++) {
 
-    if (ngx_strncmp(value[i].data, "weight=", 7) == 0) {
+        if (ngx_strncmp(value[i].data, "weight=", 7) == 0) {
 
-      if (!(uscf->flags & NGX_HTTP_UPSTREAM_WEIGHT)) {
-        goto not_supported;
-      }
+            if (!(uscf->flags & NGX_HTTP_UPSTREAM_WEIGHT)) {
+                goto not_supported;
+            }
 
-      weight = ngx_atoi(&value[i].data[7], value[i].len - 7);
+            weight = ngx_atoi(&value[i].data[7], value[i].len - 7);
 
-      if (weight == NGX_ERROR || weight == 0) {
+            if (weight == NGX_ERROR || weight == 0) {
+                goto invalid;
+            }
+
+            continue;
+        }
+
+        if (ngx_strncmp(value[i].data, "max_fails=", 10) == 0) {
+
+            if (!(uscf->flags & NGX_HTTP_UPSTREAM_MAX_FAILS)) {
+                goto not_supported;
+            }
+
+            max_fails = ngx_atoi(&value[i].data[10], value[i].len - 10);
+
+            if (max_fails == NGX_ERROR) {
+                goto invalid;
+            }
+
+            continue;
+        }
+
+        if (ngx_strncmp(value[i].data, "fail_timeout=", 13) == 0) {
+
+            if (!(uscf->flags & NGX_HTTP_UPSTREAM_FAIL_TIMEOUT)) {
+                goto not_supported;
+            }
+
+            s.len = value[i].len - 13;
+            s.data = &value[i].data[13];
+
+            fail_timeout = ngx_parse_time(&s, 1);
+
+            if (fail_timeout == (time_t) NGX_ERROR) {
+                goto invalid;
+            }
+
+            continue;
+        }
+
+        if (ngx_strcmp(value[i].data, "backup") == 0) {
+
+            if (!(uscf->flags & NGX_HTTP_UPSTREAM_BACKUP)) {
+                goto not_supported;
+            }
+
+            us->backup = 1;
+
+            continue;
+        }
+
+        if (ngx_strcmp(value[i].data, "down") == 0) {
+
+            if (!(uscf->flags & NGX_HTTP_UPSTREAM_DOWN)) {
+                goto not_supported;
+            }
+
+            us->down = 1;
+
+            continue;
+        }
+
         goto invalid;
-      }
-
-      continue;
     }
 
-    if (ngx_strncmp(value[i].data, "max_fails=", 10) == 0) {
+    ngx_memzero(&u, sizeof(ngx_url_t));
 
-      if (!(uscf->flags & NGX_HTTP_UPSTREAM_MAX_FAILS)) {
-        goto not_supported;
-      }
+    u.url = value[1];
+    u.default_port = 80;
 
-      max_fails = ngx_atoi(&value[i].data[10], value[i].len - 10);
+    // BEGIN CUSTOMIZATION: "dynamic_server" differs from "server" implementation
+    if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
+        if (u.err) {
+            ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
+                               "%s in upstream \"%V\"", u.err, &u.url);
+        }
 
-      if (max_fails == NGX_ERROR) {
-        goto invalid;
-      }
+        // If the domain fails to resolve on start up, mark this server as down,
+        // and assign a static IP that should never route. This is to account for
+        // various things inside nginx that seem to expect a server to always have
+        // at least 1 IP.
+        us->down = 1;
 
-      continue;
+        u.url = ngx_http_upstream_dynamic_server_null_route;
+        u.default_port = u.port;
+        u.no_resolve = 1;
+
+        if (ngx_parse_url(cf->pool, &u) != NGX_OK) {
+            if (u.err) {
+                ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
+                                   "%s in upstream \"%V\"", u.err, &u.url);
+            }
+
+            return NGX_CONF_ERROR;
+        }
     }
-
-    if (ngx_strncmp(value[i].data, "fail_timeout=", 13) == 0) {
-
-      if (!(uscf->flags & NGX_HTTP_UPSTREAM_FAIL_TIMEOUT)) {
-        goto not_supported;
-      }
-
-      s.len = value[i].len - 13;
-      s.data = &value[i].data[13];
-
-      fail_timeout = ngx_parse_time(&s, 1);
-
-      if (fail_timeout == (time_t) NGX_ERROR) {
-        goto invalid;
-      }
-
-      continue;
-    }
-
-    if (ngx_strcmp(value[i].data, "backup") == 0) {
-
-      if (!(uscf->flags & NGX_HTTP_UPSTREAM_BACKUP)) {
-        goto not_supported;
-      }
-
-      us->backup = 1;
-
-      continue;
-    }
-
-    if (ngx_strcmp(value[i].data, "down") == 0) {
-
-      if (!(uscf->flags & NGX_HTTP_UPSTREAM_DOWN)) {
-        goto not_supported;
-      }
-
-      us->down = 1;
-
-      continue;
-    }
-
-    goto invalid;
-  }
-
-  ngx_memzero(&u, sizeof(ngx_url_t));
-
-  u.url = value[1];
-  u.default_port = 80;
-
-  // BEGIN CUSTOMIZATION: "dynamic_server" differs from "server" implementation
-  if(ngx_parse_url(cf->pool, &u) != NGX_OK) {
-    if(u.err) {
-      ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
-          "%s in upstream \"%V\"", u.err, &u.url);
-    }
-
-    // If the domain fails to resolve on start up, mark this server as down,
-    // and assign a static IP that should never route. This is to account for
-    // various things inside nginx that seem to expect a server to always have
-    // at least 1 IP.
-    us->down = 1;
-
-    u.url = ngx_http_upstream_dynamic_server_null_route;
-    u.default_port = u.port;
-    u.no_resolve = 1;
-
-    if(ngx_parse_url(cf->pool, &u) != NGX_OK) {
-      if(u.err) {
-        ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
-            "%s in upstream \"%V\"", u.err, &u.url);
-      }
-
-      return NGX_CONF_ERROR;
-    }
-  }
-  // END CUSTOMIZATION
+    // END CUSTOMIZATION
 
 #if nginx_version >= 1007002
-  us->name = u.url;
+    us->name = u.url;
 #endif
-  us->addrs = u.addrs;
-  us->naddrs = u.naddrs;
-  us->weight = weight;
-  us->max_fails = max_fails;
-  us->fail_timeout = fail_timeout;
+    us->addrs = u.addrs;
+    us->naddrs = u.naddrs;
+    us->weight = weight;
+    us->max_fails = max_fails;
+    us->fail_timeout = fail_timeout;
 
-  // BEGIN CUSTOMIZATION: "dynamic_server" differs from "server" implementation
+    // BEGIN CUSTOMIZATION: "dynamic_server" differs from "server" implementation
 
-  // Determine if the server given is an IP address or a hostname by running
-  // through ngx_parse_url with no_resolve enabled. Only if a hostname is given
-  // will we add this to the list of dynamic servers that we will re-resolve.
-  ngx_memzero(&u, sizeof(ngx_url_t));
-  u.url = value[1];
-  u.default_port = 80;
-  u.no_resolve = 1;
-  ngx_parse_url(cf->pool, &u);
-  if(!u.addrs || !u.addrs[0].sockaddr) {
-    dynamic_server = ngx_array_push(&udsmcf->dynamic_servers);
-    if(dynamic_server == NULL) {
-      return NGX_CONF_ERROR;
+    // Determine if the server given is an IP address or a hostname by running
+    // through ngx_parse_url with no_resolve enabled. Only if a hostname is given
+    // will we add this to the list of dynamic servers that we will resolve again.
+
+    ngx_memzero(&u, sizeof(ngx_url_t));
+    u.url = value[1];
+    u.default_port = 80;
+    u.no_resolve = 1;
+    ngx_parse_url(cf->pool, &u);
+    if (!u.addrs || !u.addrs[0].sockaddr) {
+        dynamic_server = ngx_array_push(&udsmcf->dynamic_servers);
+        if (dynamic_server == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        ngx_memzero(dynamic_server, sizeof(ngx_http_upstream_dynamic_server_conf_t));
+        dynamic_server->server = us;
+        dynamic_server->upstream_conf = uscf;
+
+        dynamic_server->resolved = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_resolved_t));
+        if (dynamic_server->resolved == NULL) {
+            return NGX_CONF_ERROR;
+        }
+
+        dynamic_server->resolved->host = u.host;
+        dynamic_server->resolved->port = (in_port_t) (u.no_port ? u.default_port : u.port);
+        dynamic_server->resolved->no_port = u.no_port;
+        dynamic_server->resolver_timeout = NGX_CONF_UNSET_MSEC;
     }
+    // END CUSTOMIZATION
 
-    ngx_memzero(dynamic_server, sizeof(ngx_http_upstream_dynamic_server_conf_t));
-    dynamic_server->server = us;
-    dynamic_server->upstream_conf = uscf;
-
-    dynamic_server->resolved = ngx_pcalloc(cf->pool, sizeof(ngx_http_upstream_resolved_t));
-    if(dynamic_server->resolved == NULL) {
-      return NGX_CONF_ERROR;
-    }
-
-    dynamic_server->resolved->host = u.host;
-    dynamic_server->resolved->port = (in_port_t) (u.no_port ? u.default_port : u.port);
-    dynamic_server->resolved->no_port = u.no_port;
-    dynamic_server->resolver_timeout = NGX_CONF_UNSET_MSEC;
-  }
-  // END CUSTOMIZATION
-
-  return NGX_CONF_OK;
+    return NGX_CONF_OK;
 
 invalid:
 
-  ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-      "invalid parameter \"%V\"", &value[i]);
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                       "invalid parameter \"%V\"", &value[i]);
 
-  return NGX_CONF_ERROR;
+    return NGX_CONF_ERROR;
 
 not_supported:
 
-  ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
-      "balancing method does not support parameter \"%V\"",
-      &value[i]);
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                       "balancing method does not support parameter \"%V\"",
+                       &value[i]);
 
-  return NGX_CONF_ERROR;
+    return NGX_CONF_ERROR;
 }
 
 static void *ngx_http_upstream_dynamic_server_main_conf(ngx_conf_t *cf) {
@@ -302,306 +303,306 @@ static void *ngx_http_upstream_dynamic_server_main_conf(ngx_conf_t *cf) {
 }
 
 static char *ngx_http_upstream_dynamic_servers_merge_conf(ngx_conf_t *cf, void *parent, void *child) {
-  // If any dynamic servers are present, verify that a "resolver" is setup as
-  // the http level.
-  ngx_http_upstream_dynamic_server_main_conf_t  *udsmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_upstream_dynamic_servers_module);
+    // If any dynamic servers are present, verify that a "resolver" is setup as
+    // the http level.
+    ngx_http_upstream_dynamic_server_main_conf_t  *udsmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_upstream_dynamic_servers_module);
 
-  if(udsmcf->dynamic_servers.nelts > 0) {
-    ngx_http_core_loc_conf_t *core_loc_conf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
+    if (udsmcf->dynamic_servers.nelts > 0) {
+        ngx_http_core_loc_conf_t *core_loc_conf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
 #if nginx_version >= 1009011
-    if(core_loc_conf->resolver == NULL || core_loc_conf->resolver->connections.nelts == 0) {
+        if (core_loc_conf->resolver == NULL || core_loc_conf->resolver->connections.nelts == 0) {
 #else
-    if(core_loc_conf->resolver == NULL || core_loc_conf->resolver->udp_connections.nelts == 0) {
+        if (core_loc_conf->resolver == NULL || core_loc_conf->resolver->udp_connections.nelts == 0) {
 #endif
-      ngx_conf_log_error(NGX_LOG_ERR, cf, 0, "resolver must be defined at the 'http' level of the config");
-      return NGX_CONF_ERROR;
+            ngx_conf_log_error(NGX_LOG_ERR, cf, 0, "resolver must be defined at the 'http' level of the config");
+            return NGX_CONF_ERROR;
+        }
     }
-  }
 
-  return NGX_CONF_OK;
+    return NGX_CONF_OK;
 }
 
 static ngx_int_t ngx_http_upstream_dynamic_servers_init_process(ngx_cycle_t *cycle) {
-  ngx_http_conf_ctx_t *conf_ctx;
-  ngx_http_core_loc_conf_t *core_loc_conf;
-  ngx_uint_t i;
-  ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
-  ngx_event_t *timer;
-  ngx_uint_t refresh_in;
-  ngx_http_upstream_dynamic_server_main_conf_t  *udsmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_dynamic_servers_module);
+    ngx_http_conf_ctx_t *conf_ctx;
+    ngx_http_core_loc_conf_t *core_loc_conf;
+    ngx_uint_t i;
+    ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
+    ngx_event_t *timer;
+    ngx_uint_t refresh_in;
+    ngx_http_upstream_dynamic_server_main_conf_t  *udsmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_dynamic_servers_module);
 
-  conf_ctx = ((ngx_http_conf_ctx_t *) cycle->conf_ctx[ngx_http_module.index]);
-  core_loc_conf = conf_ctx->loc_conf[ngx_http_core_module.ctx_index];
+    conf_ctx = ((ngx_http_conf_ctx_t *) cycle->conf_ctx[ngx_http_module.index]);
+    core_loc_conf = conf_ctx->loc_conf[ngx_http_core_module.ctx_index];
 
-  if(udsmcf->dynamic_servers.nelts > 0) {
-    dynamic_server = udsmcf->dynamic_servers.elts;
-    for(i = 0; i < udsmcf->dynamic_servers.nelts; i++) {
-      dynamic_server[i].resolver = core_loc_conf->resolver;
-      ngx_conf_merge_msec_value(dynamic_server[i].resolver_timeout, core_loc_conf->resolver_timeout, 30000);
+    if (udsmcf->dynamic_servers.nelts > 0) {
+        dynamic_server = udsmcf->dynamic_servers.elts;
+        for (i = 0; i < udsmcf->dynamic_servers.nelts; i++) {
+            dynamic_server[i].resolver = core_loc_conf->resolver;
+            ngx_conf_merge_msec_value(dynamic_server[i].resolver_timeout, core_loc_conf->resolver_timeout, 30000);
 
-      timer = &dynamic_server[i].timer;
-      timer->handler = ngx_http_upstream_dynamic_server_resolve;
-      timer->log = cycle->log;
-      timer->data = &dynamic_server[i];
+            timer = &dynamic_server[i].timer;
+            timer->handler = ngx_http_upstream_dynamic_server_resolve;
+            timer->log = cycle->log;
+            timer->data = &dynamic_server[i];
 
-      refresh_in = ngx_random() % 1000;
-      ngx_log_debug(NGX_LOG_DEBUG_CORE, cycle->log, 0, "upstream-dynamic-servers: Initial DNS refresh of '%V' in %ims", &dynamic_server[i].resolved->host, refresh_in);
-      ngx_add_timer(timer, refresh_in);
+            refresh_in = ngx_random() % 1000;
+            ngx_log_debug(NGX_LOG_DEBUG_CORE, cycle->log, 0, "upstream-dynamic-servers: Initial DNS refresh of '%V' in %ims", &dynamic_server[i].resolved->host, refresh_in);
+            ngx_add_timer(timer, refresh_in);
+        }
     }
-  }
 
-  return NGX_OK;
+    return NGX_OK;
 }
 
 static void ngx_http_upstream_dynamic_servers_exit_process(ngx_cycle_t *cycle) {
-  ngx_uint_t i;
-  ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
-  ngx_http_upstream_dynamic_server_main_conf_t  *udsmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_dynamic_servers_module);
+    ngx_uint_t i;
+    ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
+    ngx_http_upstream_dynamic_server_main_conf_t  *udsmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_upstream_dynamic_servers_module);
 
-  if(udsmcf->dynamic_servers.nelts > 0) {
-    dynamic_server = udsmcf->dynamic_servers.elts;
-    for(i = 0; i < udsmcf->dynamic_servers.nelts; i++) {
-      if(dynamic_server[i].pool) {
-        ngx_destroy_pool(dynamic_server[i].pool);
-        dynamic_server[i].pool = NULL;
-      }
+    if (udsmcf->dynamic_servers.nelts > 0) {
+        dynamic_server = udsmcf->dynamic_servers.elts;
+        for (i = 0; i < udsmcf->dynamic_servers.nelts; i++) {
+            if (dynamic_server[i].pool) {
+                ngx_destroy_pool(dynamic_server[i].pool);
+                dynamic_server[i].pool = NULL;
+            }
+        }
     }
-  }
 }
 
 static void ngx_http_upstream_dynamic_server_resolve(ngx_event_t *ev) {
-  ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
-  ngx_resolver_ctx_t *ctx;
+    ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
+    ngx_resolver_ctx_t *ctx;
 
-  dynamic_server = ev->data;
+    dynamic_server = ev->data;
 
-  ctx = ngx_resolve_start(dynamic_server->resolver, NULL);
-  if(ctx == NULL) {
-    ngx_log_error(NGX_LOG_ALERT, ev->log, 0, "upstream-dynamic-servers: resolver start error for '%V'", &dynamic_server->resolved->host);
-    return;
-  }
+    ctx = ngx_resolve_start(dynamic_server->resolver, NULL);
+    if (ctx == NULL) {
+        ngx_log_error(NGX_LOG_ALERT, ev->log, 0, "upstream-dynamic-servers: resolver start error for '%V'", &dynamic_server->resolved->host);
+        return;
+    }
 
-  if(ctx == NGX_NO_RESOLVER) {
-    ngx_log_error(NGX_LOG_ALERT, ev->log, 0, "upstream-dynamic-servers: no resolver defined to resolve '%V'", &dynamic_server->resolved->host);
-    return;
-  }
+    if (ctx == NGX_NO_RESOLVER) {
+        ngx_log_error(NGX_LOG_ALERT, ev->log, 0, "upstream-dynamic-servers: no resolver defined to resolve '%V'", &dynamic_server->resolved->host);
+        return;
+    }
 
-  ctx->name = dynamic_server->resolved->host;
-  ctx->handler = ngx_http_upstream_dynamic_server_resolve_handler;
-  ctx->data = dynamic_server;
-  ctx->timeout = dynamic_server->resolver_timeout;
+    ctx->name = dynamic_server->resolved->host;
+    ctx->handler = ngx_http_upstream_dynamic_server_resolve_handler;
+    ctx->data = dynamic_server;
+    ctx->timeout = dynamic_server->resolver_timeout;
 
-  ngx_log_debug(NGX_LOG_DEBUG_CORE, ev->log, 0, "upstream-dynamic-servers: Resolving '%V'", &ctx->name);
-  if(ngx_resolve_name(ctx) != NGX_OK) {
-    ngx_log_error(NGX_LOG_ALERT, ev->log, 0, "upstream-dynamic-servers: ngx_resolve_name failed for '%V'", &ctx->name);
-  }
+    ngx_log_debug(NGX_LOG_DEBUG_CORE, ev->log, 0, "upstream-dynamic-servers: Resolving '%V'", &ctx->name);
+    if (ngx_resolve_name(ctx) != NGX_OK) {
+        ngx_log_error(NGX_LOG_ALERT, ev->log, 0, "upstream-dynamic-servers: ngx_resolve_name failed for '%V'", &ctx->name);
+    }
 }
 
 static void ngx_http_upstream_dynamic_server_resolve_handler(ngx_resolver_ctx_t *ctx) {
-  ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
-  ngx_conf_t cf;
-  uint32_t hash;
-  ngx_resolver_node_t  *rn;
-  ngx_pool_t *new_pool;
-  dynamic_server = ctx->data;
+    ngx_http_upstream_dynamic_server_conf_t *dynamic_server;
+    ngx_conf_t cf;
+    uint32_t hash;
+    ngx_resolver_node_t  *rn;
+    ngx_pool_t *new_pool;
+    dynamic_server = ctx->data;
 
-  ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: Finished resolving '%V'", &ctx->name);
+    ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: Finished resolving '%V'", &ctx->name);
 
-  if(ctx->state) {
-    ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0, "upstream-dynamic-servers: '%V' could not be resolved (%i: %s)", &ctx->name, ctx->state, ngx_resolver_strerror(ctx->state));
+    if (ctx->state) {
+        ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0, "upstream-dynamic-servers: '%V' could not be resolved (%i: %s)", &ctx->name, ctx->state, ngx_resolver_strerror(ctx->state));
 
-    ngx_url_t                    u;
-    ngx_memzero(&u, sizeof(ngx_url_t));
+        ngx_url_t                    u;
+        ngx_memzero(&u, sizeof(ngx_url_t));
 
-    // If the domain fails to resolve on start up, assign a static IP that
-    // should never route (we'll also mark it as down in the upstream later
-    // on). This is to account for various things inside nginx that seem to
-    // expect a server to always have at least 1 IP.
-    u.url = ngx_http_upstream_dynamic_server_null_route;
-    u.default_port = 80;
-    u.no_resolve = 1;
-    if(ngx_parse_url(ngx_cycle->pool, &u) != NGX_OK) {
-      if(u.err) {
-        ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0,
-            "%s in upstream \"%V\"", u.err, &u.url);
-      }
+        // If the domain fails to resolve on start up, assign a static IP that
+        // should never route (we'll also mark it as down in the upstream later
+        // on). This is to account for various things inside nginx that seem to
+        // expect a server to always have at least 1 IP.
+        u.url = ngx_http_upstream_dynamic_server_null_route;
+        u.default_port = 80;
+        u.no_resolve = 1;
+        if (ngx_parse_url(ngx_cycle->pool, &u) != NGX_OK) {
+            if (u.err) {
+                ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0,
+                              "%s in upstream \"%V\"", u.err, &u.url);
+            }
 
-      goto end;
+            goto end;
+        }
+        ctx->addrs = u.addrs;
+        ctx->naddrs = u.naddrs;
     }
-    ctx->addrs = u.addrs;
-    ctx->naddrs = u.naddrs;
-  }
 
-  if(ctx->naddrs != dynamic_server->server->naddrs) {
-    goto reinit_upstream;
-  }
-
-  ngx_uint_t i;
-  ngx_addr_t *existing_addr;
-  ngx_addr_t *new_addr;
-  for(i = 0; i < ctx->naddrs; i++) {
-    existing_addr = &dynamic_server->server->addrs[i];
-    new_addr = &ctx->addrs[i];
-
-    if(ngx_cmp_sockaddr(existing_addr->sockaddr, existing_addr->socklen, new_addr->sockaddr, new_addr->socklen, 0) != NGX_OK) {
-      goto reinit_upstream;
+    if (ctx->naddrs != dynamic_server->server->naddrs) {
+        goto reinit_upstream;
     }
-  }
 
-  ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: No DNS changes for '%V' - keeping existing upstream configuration", &ctx->name);
-  goto end;
+    ngx_uint_t i;
+    ngx_addr_t *existing_addr;
+    ngx_addr_t *new_addr;
+    for (i = 0; i < ctx->naddrs; i++) {
+        existing_addr = &dynamic_server->server->addrs[i];
+        new_addr = &ctx->addrs[i];
+
+        if (ngx_cmp_sockaddr(existing_addr->sockaddr, existing_addr->socklen, new_addr->sockaddr, new_addr->socklen, 0) != NGX_OK) {
+            goto reinit_upstream;
+        }
+    }
+
+    ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: No DNS changes for '%V' - keeping existing upstream configuration", &ctx->name);
+    goto end;
 
 reinit_upstream:
 
-  new_pool = ngx_create_pool(NGX_DEFAULT_POOL_SIZE, ctx->resolver->log);
-  if(new_pool == NULL) {
-    ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0, "upstream-dynamic-servers: Could not create new pool");
-    return;
-  }
-
-  ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: DNS changes for '%V' detected - reinitializing upstream configuration", &ctx->name);
-
-  ngx_memzero(&cf, sizeof(ngx_conf_t));
-  cf.name = "dynamic_server_init_upstream";
-  cf.pool = new_pool;
-  cf.module_type = NGX_HTTP_MODULE;
-  cf.cmd_type = NGX_HTTP_MAIN_CONF;
-  cf.log = ngx_cycle->log;
-  cf.ctx = ctx;
-
-  dynamic_server->server->naddrs = ctx->naddrs;
-
-  // If the domain failed to resolve, mark this server as down.
-  if(ctx->state) {
-    dynamic_server->server->down = 1;
-  } else {
-    dynamic_server->server->down = 0;
-  }
-
-  dynamic_server->server->addrs = ngx_pcalloc(new_pool, ctx->naddrs * sizeof(ngx_addr_t));
-  ngx_memcpy(dynamic_server->server->addrs, ctx->addrs, ctx->naddrs * sizeof(ngx_addr_t));
-
-  struct sockaddr *sockaddr;
-  ngx_addr_t *addr;
-  socklen_t socklen;
-  for(i = 0; i < ctx->naddrs; i++) {
-    addr = &dynamic_server->server->addrs[i];
-
-    socklen = ctx->addrs[i].socklen;
-
-    sockaddr = ngx_palloc(new_pool, socklen);
-    ngx_memcpy(sockaddr, ctx->addrs[i].sockaddr, socklen);
-    switch(sockaddr->sa_family) {
-    case AF_INET6:
-      ((struct sockaddr_in6 *)sockaddr)->sin6_port = htons((u_short) dynamic_server->resolved->port);
-      break;
-    default:
-      ((struct sockaddr_in *)sockaddr)->sin_port = htons((u_short) dynamic_server->resolved->port);
+    new_pool = ngx_create_pool(NGX_DEFAULT_POOL_SIZE, ctx->resolver->log);
+    if (new_pool == NULL) {
+        ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0, "upstream-dynamic-servers: Could not create new pool");
+        return;
     }
 
-    addr->sockaddr = sockaddr;
-    addr->socklen = socklen;
+    ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: DNS changes for '%V' detected - reinitializing upstream configuration", &ctx->name);
 
-    u_char *p;
-    size_t len;
+    ngx_memzero(&cf, sizeof(ngx_conf_t));
+    cf.name = "dynamic_server_init_upstream";
+    cf.pool = new_pool;
+    cf.module_type = NGX_HTTP_MODULE;
+    cf.cmd_type = NGX_HTTP_MAIN_CONF;
+    cf.log = ngx_cycle->log;
+    cf.ctx = ctx;
 
-    p = ngx_pnalloc(new_pool, NGX_SOCKADDR_STRLEN);
-    if(p == NULL) {
-      ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0, "upstream-dynamic-servers: Error initializing sockaddr");
+    dynamic_server->server->naddrs = ctx->naddrs;
+
+    // If the domain failed to resolve, mark this server as down.
+    if (ctx->state) {
+        dynamic_server->server->down = 1;
+    } else {
+        dynamic_server->server->down = 0;
     }
-    len = ngx_sock_ntop(sockaddr, socklen, p, NGX_SOCKADDR_STRLEN, 1);
-    addr->name.len = len;
-    addr->name.data = p;
-  }
+
+    dynamic_server->server->addrs = ngx_pcalloc(new_pool, ctx->naddrs * sizeof(ngx_addr_t));
+    ngx_memcpy(dynamic_server->server->addrs, ctx->addrs, ctx->naddrs * sizeof(ngx_addr_t));
+
+    struct sockaddr *sockaddr;
+    ngx_addr_t *addr;
+    socklen_t socklen;
+    for (i = 0; i < ctx->naddrs; i++) {
+        addr = &dynamic_server->server->addrs[i];
+
+        socklen = ctx->addrs[i].socklen;
+
+        sockaddr = ngx_palloc(new_pool, socklen);
+        ngx_memcpy(sockaddr, ctx->addrs[i].sockaddr, socklen);
+        switch(sockaddr->sa_family) {
+        case AF_INET6:
+            ((struct sockaddr_in6 *)sockaddr)->sin6_port = htons((u_short) dynamic_server->resolved->port);
+            break;
+        default:
+            ((struct sockaddr_in *)sockaddr)->sin_port = htons((u_short) dynamic_server->resolved->port);
+        }
+
+        addr->sockaddr = sockaddr;
+        addr->socklen = socklen;
+
+        u_char *p;
+        size_t len;
+
+        p = ngx_pnalloc(new_pool, NGX_SOCKADDR_STRLEN);
+        if (p == NULL) {
+            ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0, "upstream-dynamic-servers: Error initializing sockaddr");
+        }
+        len = ngx_sock_ntop(sockaddr, socklen, p, NGX_SOCKADDR_STRLEN, 1);
+        addr->name.len = len;
+        addr->name.data = p;
+    }
 
 #if (NGX_DEBUG)
-  {
-    u_char text[NGX_SOCKADDR_STRLEN];
-    ngx_str_t addr;
-    ngx_uint_t i;
-    addr.data = text;
-    for(i = 0; i < ctx->naddrs; i++) {
-      addr.len = ngx_sock_ntop(ctx->addrs[i].sockaddr, ctx->addrs[i].socklen, text, NGX_SOCKADDR_STRLEN, 0);
-      ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: '%V' was resolved to '%V'", &ctx->name, &addr);
+    {
+        u_char text[NGX_SOCKADDR_STRLEN];
+        ngx_str_t addr;
+        ngx_uint_t i;
+        addr.data = text;
+        for (i = 0; i < ctx->naddrs; i++) {
+            addr.len = ngx_sock_ntop(ctx->addrs[i].sockaddr, ctx->addrs[i].socklen, text, NGX_SOCKADDR_STRLEN, 0);
+            ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: '%V' was resolved to '%V'", &ctx->name, &addr);
+        }
     }
-  }
 #endif
 
-  ngx_http_upstream_init_pt init;
-  init = dynamic_server->upstream_conf->peer.init_upstream ? dynamic_server->upstream_conf->peer.init_upstream : ngx_http_upstream_init_round_robin;
+    ngx_http_upstream_init_pt init;
+    init = dynamic_server->upstream_conf->peer.init_upstream ? dynamic_server->upstream_conf->peer.init_upstream : ngx_http_upstream_init_round_robin;
 
-  if(init(&cf, dynamic_server->upstream_conf) != NGX_OK) {
-    ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0, "upstream-dynamic-servers: Error re-initializing upstream after DNS changes");
-  }
+    if (init(&cf, dynamic_server->upstream_conf) != NGX_OK) {
+        ngx_log_error(NGX_LOG_ERR, ctx->resolver->log, 0, "upstream-dynamic-servers: Error re-initializing upstream after DNS changes");
+    }
 
-  if(dynamic_server->previous_pool != NULL) {
-    ngx_destroy_pool(dynamic_server->previous_pool);
-    dynamic_server->previous_pool = NULL;
-  }
+    if (dynamic_server->previous_pool != NULL) {
+        ngx_destroy_pool(dynamic_server->previous_pool);
+        dynamic_server->previous_pool = NULL;
+    }
 
-  dynamic_server->previous_pool = dynamic_server->pool;
-  dynamic_server->pool = new_pool;
+    dynamic_server->previous_pool = dynamic_server->pool;
+    dynamic_server->pool = new_pool;
 
 end:
 
-  hash = ngx_crc32_short(ctx->name.data, ctx->name.len);
-  rn = ngx_resolver_lookup_name(ctx->resolver, &ctx->name, hash);
-  uint32_t refresh_in;
-  if(rn != NULL && rn->ttl) {
-    refresh_in = (rn->valid - ngx_time()) * 1000;
+    hash = ngx_crc32_short(ctx->name.data, ctx->name.len);
+    rn = ngx_resolver_lookup_name(ctx->resolver, &ctx->name, hash);
+    uint32_t refresh_in;
+    if (rn != NULL && rn->ttl) {
+        refresh_in = (rn->valid - ngx_time()) * 1000;
 
-    if(!refresh_in || refresh_in < 1000) {
-      refresh_in = 1000;
+        if (!refresh_in || refresh_in < 1000) {
+            refresh_in = 1000;
+        }
+    } else {
+        refresh_in = 1000;
     }
-  } else {
-    refresh_in = 1000;
-  }
 
-  ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: Refreshing DNS of '%V' in %ims", &ctx->name, refresh_in);
-  ngx_resolve_name_done(ctx);
+    ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: Refreshing DNS of '%V' in %ims", &ctx->name, refresh_in);
+    ngx_resolve_name_done(ctx);
 
-  if (ngx_exiting) {
-    ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: worker is about to exit, do not set the timer again");
-    return;
-  }
+    if (ngx_exiting) {
+        ngx_log_debug(NGX_LOG_DEBUG_CORE, ctx->resolver->log, 0, "upstream-dynamic-servers: worker is about to exit, do not set the timer again");
+        return;
+    }
 
-  ngx_add_timer(&dynamic_server->timer, 1000);
+    ngx_add_timer(&dynamic_server->timer, 1000);
 }
 
 // Copied from src/core/ngx_resolver.c (nginx version 1.7.7).
 static ngx_resolver_node_t * ngx_resolver_lookup_name(ngx_resolver_t *r, ngx_str_t *name, uint32_t hash) {
-  ngx_int_t rc;
-  ngx_rbtree_node_t *node, *sentinel;
-  ngx_resolver_node_t *rn;
+    ngx_int_t rc;
+    ngx_rbtree_node_t *node, *sentinel;
+    ngx_resolver_node_t *rn;
 
-  node = r->name_rbtree.root;
-  sentinel = r->name_rbtree.sentinel;
+    node = r->name_rbtree.root;
+    sentinel = r->name_rbtree.sentinel;
 
-  while(node != sentinel) {
-    if(hash < node->key) {
-      node = node->left;
-      continue;
+    while (node != sentinel) {
+        if (hash < node->key) {
+            node = node->left;
+            continue;
+        }
+
+        if (hash > node->key) {
+            node = node->right;
+            continue;
+        }
+
+        /* hash == node->key */
+
+        rn = ngx_resolver_node(node);
+
+        rc = ngx_memn2cmp(name->data, rn->name, name->len, rn->nlen);
+
+        if (rc == 0) {
+            return rn;
+        }
+
+        node = (rc < 0) ? node->left : node->right;
     }
 
-    if(hash > node->key) {
-      node = node->right;
-      continue;
-    }
+    /* not found */
 
-    /* hash == node->key */
-
-    rn = ngx_resolver_node(node);
-
-    rc = ngx_memn2cmp(name->data, rn->name, name->len, rn->nlen);
-
-    if(rc == 0) {
-      return rn;
-    }
-
-    node = (rc < 0) ? node->left : node->right;
-  }
-
-  /* not found */
-
-  return NULL;
+    return NULL;
 }

--- a/t/dynamic_server.t
+++ b/t/dynamic_server.t
@@ -83,7 +83,7 @@ __DATA__
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server foo.blah;
+      server foo.blah resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -100,7 +100,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server use.opendns.com;
+      server use.opendns.com resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -134,7 +134,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server use.opendns.com:8080;
+      server use.opendns.com:8080 resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -168,7 +168,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server 10.10.10.10;
+      server 10.10.10.10 resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -195,7 +195,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server [fe80::0202:b3ff:fe1e:8329];
+      server [fe80::0202:b3ff:fe1e:8329] resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -222,7 +222,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server [fe80::0202:b3ff:fe1e:8329]:8081;
+      server [fe80::0202:b3ff:fe1e:8329]:8081 resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -243,12 +243,12 @@ upstream test_upstream:
   addr = [fe80::0202:b3ff:fe1e:8329]:8081, weight = 1, fail_timeout = 10, max_fails = 1
 
 
-=== TEST 7: fails to start if the http level resolver is missing and a dynamic_server is present
+=== TEST 7: fails to start if the http level resolver is missing and a server is present
 --- http_config
     $TEST_NGINX_BASE_HTTP_CONF
 
     upstream test_upstream {
-      dynamic_server use.opendns.com;
+      server use.opendns.com resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -256,7 +256,7 @@ upstream test_upstream:
 --- error_log
 resolver must be defined
 
-=== TEST 8: starts if the http level resolver is missing and a dynamic_server is not present
+=== TEST 8: starts if the http level resolver is missing and a server is not present
 --- http_config
     $TEST_NGINX_BASE_HTTP_CONF
 
@@ -278,7 +278,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server use.opendns.com;
+      server use.opendns.com resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -307,7 +307,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server use.opendns.com;
+      server use.opendns.com resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -350,7 +350,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server foo.blah;
+      server foo.blah resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -379,7 +379,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server foo.blah;
+      server foo.blah resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -410,7 +410,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server use.opendns.com;
+      server use.opendns.com resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -454,7 +454,7 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server multi.blah;
+      server multi.blah resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -485,8 +485,8 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server use.opendns.com weight=4 max_fails=8 fail_timeout=7;
-      dynamic_server 127.0.0.8 backup down;
+      server use.opendns.com weight=4 max_fails=8 fail_timeout=7 resolve;
+      server 127.0.0.8 backup down resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -504,21 +504,21 @@ upstream test_upstream:
 
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
-      dynamic_server google.blah;
-      dynamic_server yahoo.blah;
-      dynamic_server bing.blah;
+      server google.blah resolve;
+      server yahoo.blah resolve;
+      server bing.blah resolve;
     }
 
     upstream test_upstream2 {
-      dynamic_server youtube.blah;
-      dynamic_server vimeo.blah;
-      dynamic_server netflix.blah;
+      server youtube.blah resolve;
+      server vimeo.blah resolve;
+      server netflix.blah resolve;
     }
 
     upstream test_upstream3 {
-      dynamic_server a.blah;
-      dynamic_server b.blah;
-      dynamic_server c.blah;
+      server a.blah resolve;
+      server b.blah resolve;
+      server c.blah resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -612,7 +612,7 @@ upstream test_upstream3:
     resolver $TEST_NGINX_RESOLVER;
     upstream test_upstream {
       keepalive 30;
-      dynamic_server local.blah:1983;
+      server local.blah:1983 resolve;
     }
 --- config
     $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
@@ -653,3 +653,32 @@ upstream test_upstream:
   addr = 127.255.255.255:1983, weight = 1, fail_timeout = 10, down = true, max_fails = 1
 502
 --- timeout: 20s
+
+=== TEST 18: do not resolve the IP if the server isn't set to do it
+--- http_config
+    $TEST_NGINX_BASE_HTTP_CONF
+
+    resolver $TEST_NGINX_RESOLVER;
+    upstream test_upstream {
+      server foo.blah;
+    }
+--- config
+    $TEST_NGINX_PRINT_UPSTREAMS_LOCATION
+
+    location = /test {
+      content_by_lua '
+        ngx.sleep(2.1)
+        ngx.print(ngx.location.capture("/print-upstreams").body)
+        set_dns_records({"foo.blah 1 A 127.5.5.5"})
+        ngx.sleep(2.1)
+        ngx.print(ngx.location.capture("/print-upstreams").body)
+      ';
+    }
+--- request
+    GET /test
+--- response_body
+upstream test_upstream:
+  addr = 127.255.255.255:80, weight = 1, fail_timeout = 10, down = true, max_fails = 1
+upstream test_upstream:
+  addr = 127.255.255.255:80, weight = 1, fail_timeout = 10, down = true, max_fails = 1
+--- timeout: 5s


### PR DESCRIPTION
Replaced "dynamic_server" directive by "server" and only enable the dynamic DNS resolution if the "resolve" parameter was used.
This is the same syntax used on nginx plls.