### PR TITLE
Worker crashes when using S3 / sites with very short DNS TTL #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ The following parameters can be used (see nginx's [server documentation](http://
 
 # Compatibility
 
-Tested with nginx 1.6, 1.7, 1.8, 1.9.
+Tested and in production on a large website (10+ machines) running nginx 1.12. 
+
+It may work with other versions, but I have not tested it. 
+
+## Incompatibility
+Currently only works with round robin and keepalive connections. The system could possibly
+be extended to work with other types of connecitons, but I have not tested it. 
 
 ## Alternatives
 
@@ -64,3 +70,28 @@ Tested with nginx 1.6, 1.7, 1.8, 1.9.
 ## License
 
 nginx-upstream-dynamic-servers is open sourced under the [MIT license](https://github.com/GUI/nginx-upstream-dynamic-servers/blob/master/LICENSE.txt).
+
+## Difference with GUI/nginx-upstream-dynamic-servers: 
+
+* This module resolves issues with fast DNS TTL and keepalive/persistant connections. 
+  * S3 has such a TTL scheme.  
+    
+Ideally, the DNS TTL on an upstream URI should be at least the maximum connection time. 
+If this isn't the case, segfaults can occur due to the peer data structure being freed before
+the request is finished.
+
+This module adds a reference counting scheme on requests that reference the current resolution. 
+Once all requests that are referencing a set of peers have been closed, the peer data is no longer needed
+we then ensure that the stored SSL contexts are all freed and free the pool that the peers were allocated
+on to ensure that the system does not leak, and that the system does not refrence unallocated memory.
+
+
+# Future Enhancement
+* Some DNS (Like S3) send one balanced DNS, instead of the multitude of servers that are available.  This means that we only get one upstream and it changes every minute or so  (Whatever the TTL is).  Instead, we could supply our own ttl and keep the last N upstreams. 
+
+Something like this: 
+```
+server domain.dns resolve rotate=5 force_ttl=60;
+```
+
+* Make other peer types work as well.  


### PR DESCRIPTION
Use a reference counting scheme on open requests to keep the dynamic sever memory alive while a request could still have a reference to an old peer.